### PR TITLE
chore: Housekeeping Terraform modules mostly to spec 

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -22,12 +22,10 @@ charm-libs:
 config:
   options:
     config-file:
-      description: |
-        Text contents of the conserver.cf config file.
+      description: Base64 encoded contents of the conserver.cf configuration file.
       type: string
     passwd-file:
-      description: |
-        Base64 encoded contents of the passwd file.
+      description: Base64 encoded contents of the conserver.passwd file.
       default: "IyBDb25zZXJ2ZXIgcGFzc3dkIGZpbGUKIyBGb3JtYXQ6IHVzZXJuYW1lOiQxJFkwWmpNbTJoJG9NWDVVeUxpMS95MFE5SVJXZjN2LzAKIyB5b3UgY2FuIGdlbmVyYXRlIHRoZSBoYXNoZWQgcGFzc3dvcmQgdXNpbmcgYG9wZW5zc2wgcGFzc3dkIC0xYAo="
       type: string
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -13,14 +13,15 @@ This module requires a `juju` model to be available. Refer to the
 
 ### Inputs
 
-| Name          | Type   | Description                                 | Default       |
-| ------------- | ------ | ------------------------------------------- | ------------- |
-| app_name      | string | Name of the Juju application                | conserver     |
-| charm_channel | string | Channel to use for the charm                | latest/stable |
-| config_file   | string | Base64 encoded contents of conserver.cf     |               |
-| juju_model    | string | Name of the Juju model to deploy into       |               |
-| passwd_file   | string | Base64 encoded contents of conserver.passwd |               |
-| revision      | number | Revision to use for the charm               | null          |
+| Name          | Type   | Description                                     | Default       |
+| ------------- | ------ | ----------------------------------------------- | ------------- |
+| app_name      | string | Name of the Juju application                    | conserver     |
+| charm_channel | string | Channel to use for the charm                    | latest/stable |
+| config_file   | string | Base64 encoded contents of conserver.cf         |               |
+| constraints   | string | String listing constraints for this application | arch=amd64    |
+| juju_model    | string | Name of the Juju model to deploy into           |               |
+| passwd_file   | string | Base64 encoded contents of conserver.passwd     |               |
+| revision      | number | Revision to use for the charm                   | null          |
 
 ### Outputs
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,45 @@
+# Terraform Module for Conserver
+
+This is a Terraform module facilitating the deployment of the Conserver charm,
+using the [Terraform Juju provider][juju-provider]. For more information, refer
+to the provider [documentation][juju-provider-docs].
+
+## Requirements
+
+This module requires a `juju` model to be available. Refer to the
+[usage section](#usage) below for more details
+
+## API
+
+### Inputs
+
+| Name          | Type   | Description                                 | Default       |
+| ------------- | ------ | ------------------------------------------- | ------------- |
+| app_name      | string | Name of the Juju application                | conserver     |
+| juju_model    | string | Name of the Juju model to deploy into       |               |
+| charm_channel | string | Channel to use for the charm                | latest/stable |
+| revision      | number | Revision to use for the charm               | null          |
+| config_file   | string | Base64 encoded contents of conserver.cf     |               |
+| passwd_file   | string | Base64 encoded contents of conserver.passwd |               |
+
+### Outputs
+
+| Name     | Type   | Description                  |
+| -------- | ------ | ---------------------------- |
+| app_name | string | Name of the Juju application |
+
+## Usage
+
+### Basic Usage
+
+Users should ensure that Terraform is aware of the `juju_model` dependency of
+the charm module.
+
+To deploy this module, you can run
+
+```shell
+terraform apply -var="juju_model=<MODEL_NAME>" -auto-approve
+```
+
+[juju-provider]: https://github.com/juju/terraform-provider-juju/
+[juju-provider-docs]: https://registry.terraform.io/providers/juju/juju/latest/docs

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -13,21 +13,21 @@ This module requires a `juju` model to be available. Refer to the
 
 ### Inputs
 
-| Name          | Type   | Description                                     | Default       |
-| ------------- | ------ | ----------------------------------------------- | ------------- |
-| app_name      | string | Name of the Juju application                    | conserver     |
-| charm_channel | string | Channel to use for the charm                    | latest/stable |
-| config_file   | string | Base64 encoded contents of conserver.cf         |               |
-| constraints   | string | String listing constraints for this application | arch=amd64    |
-| juju_model    | string | Name of the Juju model to deploy into           |               |
-| passwd_file   | string | Base64 encoded contents of conserver.passwd     |               |
-| revision      | number | Revision to use for the charm                   | null          |
+| Name          | Type   | Description                                                                       | Default       |
+| ------------- | ------ | --------------------------------------------------------------------------------- | ------------- |
+| app_name      | string | Name to give the deployed application                                             | conserver     |
+| charm_channel | string | Channel of the charm                                                              | latest/stable |
+| config_file   | string | Base64 encoded contents of conserver.cf                                           |               |
+| constraints   | string | String listing constraints for this application                                   | arch=amd64    |
+| juju_model    | string | Reference to an existing model resource or data source for the model to deploy to |               |
+| passwd_file   | string | Base64 encoded contents of conserver.passwd                                       |               |
+| revision      | number | Revision number of the charm                                                      | null          |
 
 ### Outputs
 
-| Name     | Type   | Description                  |
-| -------- | ------ | ---------------------------- |
-| app_name | string | Name of the Juju application |
+| Name     | Type   | Description                      |
+| -------- | ------ | -------------------------------- |
+| app_name | string | Name of the deployed application |
 
 ## Usage
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,11 +16,11 @@ This module requires a `juju` model to be available. Refer to the
 | Name          | Type   | Description                                 | Default       |
 | ------------- | ------ | ------------------------------------------- | ------------- |
 | app_name      | string | Name of the Juju application                | conserver     |
-| juju_model    | string | Name of the Juju model to deploy into       |               |
 | charm_channel | string | Channel to use for the charm                | latest/stable |
-| revision      | number | Revision to use for the charm               | null          |
 | config_file   | string | Base64 encoded contents of conserver.cf     |               |
+| juju_model    | string | Name of the Juju model to deploy into       |               |
 | passwd_file   | string | Base64 encoded contents of conserver.passwd |               |
+| revision      | number | Revision to use for the charm               | null          |
 
 ### Outputs
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 resource "juju_application" "conserver" {
-  name  = "conserver"
+  name  = var.app_name
   model = var.juju_model
 
   units = 1

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,8 +1,8 @@
 resource "juju_application" "conserver" {
-  name  = var.app_name
-  model = var.juju_model
-
-  units = 1
+  name        = var.app_name
+  constraints = var.constraints
+  model       = var.juju_model
+  units       = 1
 
   charm {
     name     = "conserver"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,9 +5,10 @@ resource "juju_application" "conserver" {
   units = 1
 
   charm {
-    name    = "conserver"
-    base    = "ubuntu@22.04"
-    channel = var.charm_channel
+    name     = "conserver"
+    base     = "ubuntu@22.04"
+    channel  = var.charm_channel
+    revision = var.revision
   }
 
   config = {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "app_name" {
+  description = "Name of the deployed application"
+  value       = juju_application.conserver.name
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,9 @@
+variable "app_name" {
+  description = "Name to give the deployed application"
+  type        = string
+  default     = "conserver"
+}
+
 variable "juju_model" {
   description = "Name of the Juju model to deploy into"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,6 +15,12 @@ variable "config_file" {
   type        = string
 }
 
+variable "constraints" {
+  description = "String listing constraints for this application"
+  type        = string
+  default     = "arch=amd64"
+}
+
 variable "juju_model" {
   description = "Name of the Juju model to deploy into"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,22 +4,10 @@ variable "app_name" {
   default     = "conserver"
 }
 
-variable "juju_model" {
-  description = "Name of the Juju model to deploy into"
-  type        = string
-}
-
 variable "charm_channel" {
   description = "Channel to use for the charm (e.g., 'latest/stable')"
   type        = string
   default     = "latest/stable"
-}
-
-variable "revision" {
-  description = "Revision number of the charm to use"
-  type        = number
-  nullable    = true
-  default     = null
 }
 
 variable "config_file" {
@@ -27,8 +15,20 @@ variable "config_file" {
   type        = string
 }
 
+variable "juju_model" {
+  description = "Name of the Juju model to deploy into"
+  type        = string
+}
+
 variable "passwd_file" {
   description = "Base64 encoded content for the conserver.passwd file"
   type        = string
   sensitive   = true
+}
+
+variable "revision" {
+  description = "Revision number of the charm to use"
+  type        = number
+  nullable    = true
+  default     = null
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,7 +5,7 @@ variable "app_name" {
 }
 
 variable "charm_channel" {
-  description = "Channel to use for the charm (e.g., 'latest/stable')"
+  description = "Channel of the charm"
   type        = string
   default     = "latest/stable"
 }
@@ -22,7 +22,7 @@ variable "constraints" {
 }
 
 variable "juju_model" {
-  description = "Name of the Juju model to deploy into"
+  description = "Reference to an existing model resource or data source for the model to deploy to"
   type        = string
 }
 
@@ -33,7 +33,7 @@ variable "passwd_file" {
 }
 
 variable "revision" {
-  description = "Revision number of the charm to use"
+  description = "Revision number of the charm"
   type        = number
   nullable    = true
   default     = null

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,7 +10,7 @@ variable "charm_channel" {
 }
 
 variable "config_file" {
-  description = "Content for the conserver.cf configuration file"
+  description = "Base64 encoded content for the conserver.cf configuration file"
   type        = string
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -30,4 +30,5 @@ variable "config_file" {
 variable "passwd_file" {
   description = "Base64 encoded content for the conserver.passwd file"
   type        = string
+  sensitive   = true
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,6 +15,13 @@ variable "charm_channel" {
   default     = "latest/stable"
 }
 
+variable "revision" {
+  description = "Revision number of the charm to use"
+  type        = number
+  nullable    = true
+  default     = null
+}
+
 variable "config_file" {
   description = "Base64 encoded content for the conserver.cf configuration file"
   type        = string


### PR DESCRIPTION
This PR updates the Terraform module up to our organization standards.

This PR is just one step towards that end, as it only makes changes that are non-breaking:

- Add `app_name` variable, defaults to `conserver`
- Add `constraints` variable, defaults to `arch=amd64`
- Add `revision` variable, defaults to `null`
- Add `outputs.tf` (we only need `app_name` in our case since our charm doesn't provide or require anything)
- Add `README.md`  documenting basic usage

The following changes would still be needed in a follow-up PR if we wish to follow the spec completely:

- Rename `charm_channel` variable to `channel`
- Replace `config_file` and `passwd_file` variables with a single `config` `map(string)` map for configuration options

And the following I believe does not apply for this charm:

- `units` variable. I don't think our charm is really designed to work with multiple units at the moment

See: https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit?tab=t.0