### PR TITLE
ci: Use `ubuntu-latest`

### DIFF
--- a/.github/workflows/charm-check-libs.yaml
+++ b/.github/workflows/charm-check-libs.yaml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   check-libs:
     name: Check Charm libraries
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write # required to label PR based on results

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-and-publish-charm:
     name: Build and Publish Charm
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
This PR updates the workflows to use `ubuntu-latest` instead of`ubuntu-22.04`. Since `charmcraft` uses containers to build and test the charms, these workflows should work regardless of what version of Ubuntu is running on the host.

This should also slightly reduce our renovate PR requests.