### PR TITLE
refactor: Refactor conserver workload out into its own module

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -73,6 +73,7 @@ class ConserverCharm(ops.CharmBase):
     def _on_start(self, _):
         """Handle start event."""
         self.conserver.start(ignore_errors=True)
+        self.unit.set_workload_version(self.conserver.version)
         self.set_status()
 
     def _on_stop(self, _):

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,19 +7,13 @@
 import base64
 import binascii
 import logging
-import os
-import pwd
-from pathlib import Path
 from typing import Optional, cast
 
 import ops
-from charmlibs import apt, systemd
+
+from conserver import Conserver
 
 logger = logging.getLogger(__name__)
-
-SERVER_CONFIG = "/etc/conserver/server.conf"
-CONSERVER_CONFIG = "/etc/conserver/conserver.cf"
-CONSERVER_PASSWD = "/etc/conserver/conserver.passwd"
 
 
 class ConserverCharm(ops.CharmBase):
@@ -27,8 +21,7 @@ class ConserverCharm(ops.CharmBase):
 
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
-        self.conserver_deb = apt.DebianPackage.from_system("conserver-server")
-        self.ipmitool_deb = apt.DebianPackage.from_system("ipmitool")
+        self.conserver = Conserver()
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.start, self._on_start)
@@ -59,17 +52,7 @@ class ConserverCharm(ops.CharmBase):
     def _on_install(self, _):
         """Handle install event."""
         self.unit.status = ops.MaintenanceStatus("Installing conserver-server")
-        self.conserver_deb.ensure(apt.PackageState.Latest)
-        self.ipmitool_deb.ensure(apt.PackageState.Latest)
-
-        # Keep default port for incoming connections at 3109
-        # and set base port for established connections at 33000
-        server_config = "OPTS='-p 3109 -b 33000  '\nASROOT=\n"
-        try:
-            Path(SERVER_CONFIG).write_text(server_config, encoding="utf-8")
-        except (OSError, UnicodeError) as e:
-            logger.exception("Failed to write server.conf: %s", e)
-            self.unit.status = ops.BlockedStatus("Failed to write server.conf")
+        self.conserver.install()
 
     def _on_config_changed(self, _):
         """Handle changes in configuration."""
@@ -77,43 +60,25 @@ class ConserverCharm(ops.CharmBase):
 
         conserver_cf = self.conserver_cf
         if conserver_cf:
-            self._write_file(conserver_cf, Path(CONSERVER_CONFIG))
+            self.conserver.write_conserver_config(conserver_cf)
 
         conserver_passwd = self.conserver_passwd
         if conserver_passwd:
-            self._write_file(
-                conserver_passwd,
-                Path(CONSERVER_PASSWD),
-                uid=pwd.getpwnam("conservr").pw_uid,
-                mode=0o600,
-            )
+            self.conserver.write_passwd_file(conserver_passwd)
 
         # Restart service to apply changes
-        try:
-            systemd.service_reload("conserver-server", restart_on_failure=True)
-            logger.info("Reloaded Conserver service successfully")
-        except systemd.SystemdError as e:
-            logger.exception("Failed to reload Conserver service: %s", e)
+        self.conserver.reload(restart_on_failure=True, ignore_errors=True)
         self.set_status()
 
     def _on_start(self, _):
         """Handle start event."""
-        try:
-            systemd.service_enable("--now", "conserver-server")
-            logger.info("Enabled and started Conserver service successfully")
-        except systemd.SystemdError as e:
-            logger.exception("Failed to enable/start Conserver service: %s", e)
+        self.conserver.start(ignore_errors=True)
         self.set_status()
 
     def _on_stop(self, _):
         """Handle stop event."""
-        try:
-            systemd.service_disable("--now", "conserver-server")
-            logger.info("Disabled and stopped Conserver service successfully")
-        except systemd.SystemdError as e:
-            logger.exception("Failed to disable/stop Conserver service: %s", e)
-        self.conserver_deb.ensure(apt.PackageState.Absent)
-        self.ipmitool_deb.ensure(apt.PackageState.Absent)
+        self.conserver.stop(ignore_errors=True)
+        self.conserver.uninstall()
 
     def set_status(self):
         """Calculate and set the unit status."""
@@ -134,27 +99,12 @@ class ConserverCharm(ops.CharmBase):
             self.unit.status = ops.BlockedStatus("Invalid value for passwd-file")
             return
 
-        if systemd.service_running("conserver-server"):
+        if self.conserver.running:
             self.unit.status = ops.ActiveStatus()
-        elif systemd.service_failed("conserver-server"):
+        elif self.conserver.failed:
             self.unit.status = ops.BlockedStatus("Conserver service has failed")
         else:
             self.unit.status = ops.MaintenanceStatus()
-
-    def _write_file(
-        self, contents: str, path: Path, uid: int = 0, gid: int = 0, mode: int = 0o644
-    ):
-        """Write contents to a file."""
-        try:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(contents, encoding="utf-8")
-            logger.info("Wrote %s successfully", path.name)
-        except OSError as e:
-            logger.exception("Failed to write %s: %s", path.name, e)
-            return False
-        os.chown(path, uid, gid)
-        path.chmod(mode)
-        return True
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/conserver.py
+++ b/src/conserver.py
@@ -1,0 +1,131 @@
+"""Functions for managing and interacting with conserver."""
+
+import logging
+import os
+import pwd
+import re
+import subprocess
+from pathlib import Path
+
+from charmlibs import apt, systemd
+
+logger = logging.getLogger(__name__)
+
+CONSERVER_DEB = "conserver-server"
+IPMITOOL_DEB = "ipmitool"
+CONSERVER_SERVICE = "conserver-server"
+CONSERVER_USER = "conservr"
+
+SERVER_CONF = "/etc/conserver/server.conf"
+CONSERVER_CF = "/etc/conserver/conserver.cf"
+CONSERVER_PASSWD = "/etc/conserver/conserver.passwd"
+
+# Keep default port for incoming connections at 3109
+# and set base port for established connections at 33000
+SERVER_CONFIG = "OPTS='-p 3109 -b 33000  '\nASROOT=\n"
+
+
+class Conserver:
+    """Represents the conserver application/workload."""
+
+    def __init__(self):
+        self.conserver_deb = apt.DebianPackage.from_system(CONSERVER_DEB)
+        self.ipmitool_deb = apt.DebianPackage.from_system(IPMITOOL_DEB)
+
+    @property
+    def version(self) -> str:
+        """Get the installed version of conserver."""
+        proc = subprocess.run(
+            ["conserver", "-V"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        stdout = proc.stdout.decode().strip()
+        match = re.search(r"conserver.com version (\S+)", stdout)
+        if match:
+            return match.group(1)
+        return "unknown"
+
+    @property
+    def uid(self) -> int:
+        """Get the conserver user identifier."""
+        return pwd.getpwnam(CONSERVER_USER).pw_uid
+
+    @property
+    def running(self) -> bool:
+        """Check if the conserver service is running."""
+        return systemd.service_running(CONSERVER_SERVICE)
+
+    @property
+    def failed(self) -> bool:
+        """Check if the conserver service has failed."""
+        return systemd.service_failed(CONSERVER_SERVICE)
+
+    def install(self) -> None:
+        """Install conserver."""
+        self.conserver_deb.ensure(apt.PackageState.Latest)
+        self.ipmitool_deb.ensure(apt.PackageState.Latest)
+        self.write_server_config()
+
+    def uninstall(self) -> None:
+        """Uninstall conserver."""
+        self.conserver_deb.ensure(apt.PackageState.Absent)
+        self.ipmitool_deb.ensure(apt.PackageState.Absent)
+
+    def start(self, ignore_errors: bool = False) -> None:
+        """Start the conserver service."""
+        try:
+            systemd.service_enable("--now", CONSERVER_SERVICE)
+            logger.info("Started %s service", CONSERVER_SERVICE)
+        except systemd.SystemdError as e:
+            logger.error("Failed to start %s service: %s", CONSERVER_SERVICE, e)
+            if not ignore_errors:
+                raise
+
+    def reload(self, restart_on_failure: bool = False, ignore_errors: bool = False) -> None:
+        """Reload the conserver service."""
+        try:
+            systemd.service_reload(CONSERVER_SERVICE, restart_on_failure=restart_on_failure)
+            logger.info("Reloaded %s service", CONSERVER_SERVICE)
+        except systemd.SystemdError as e:
+            logger.error("Failed to reload %s service: %s", CONSERVER_SERVICE, e)
+            if not ignore_errors:
+                raise
+
+    def stop(self, ignore_errors: bool = False) -> None:
+        """Stop the conserver service."""
+        try:
+            systemd.service_disable("--now", CONSERVER_SERVICE)
+            logger.info("Stopped %s service", CONSERVER_SERVICE)
+        except systemd.SystemdError as e:
+            logger.error("Failed to stop %s service: %s", CONSERVER_SERVICE, e)
+            if not ignore_errors:
+                raise
+
+    def write_server_config(self) -> None:
+        """Write the server.conf file."""
+        try:
+            Path(SERVER_CONF).write_text(SERVER_CONFIG, encoding="utf-8")
+        except (OSError, UnicodeError) as e:
+            logger.error("Failed to write %s: %s", SERVER_CONF, e)
+            raise
+
+    def write_conserver_config(self, contents: str) -> None:
+        """Write the conserver.cf file."""
+        path = Path(CONSERVER_CF)
+        try:
+            path.write_text(contents, encoding="utf-8")
+        except (OSError, UnicodeError) as e:
+            logger.error("Failed to write %s: %s", CONSERVER_CF, e)
+            raise
+        os.chown(path, 0, 0)
+        path.chmod(0o644)
+
+    def write_passwd_file(self, contents: str) -> None:
+        """Write the conserver.passwd file."""
+        path = Path(CONSERVER_PASSWD)
+        try:
+            path.write_text(contents, encoding="utf-8")
+        except (OSError, UnicodeError) as e:
+            logger.error("Failed to write %s: %s", CONSERVER_PASSWD, e)
+            raise
+        os.chown(path, self.uid, 0)
+        path.chmod(0o600)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -13,3 +13,11 @@ def test_deploy(charm: Path, juju: jubilant.Juju, config_file: str):
     config = {"config-file": config_file}
     juju.deploy(charm.resolve(), config=config, app=APP_NAME)
     juju.wait(jubilant.all_active, timeout=300)
+
+
+def test_workload_version_is_set(juju: jubilant.Juju):
+    """Test that the workload version is set after deployment."""
+    version = juju.status().apps[APP_NAME].version
+    task = juju.exec("conserver -V", unit=f"{APP_NAME}/0")
+    version_output = task.stdout.strip()
+    assert f"conserver.com version {version}" in version_output

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,9 +5,11 @@ import jubilant
 
 logger = logging.getLogger(__name__)
 
+APP_NAME = "conserver"
+
 
 def test_deploy(charm: Path, juju: jubilant.Juju, config_file: str):
     """Deploy the charm under test."""
     config = {"config-file": config_file}
-    juju.deploy(charm.resolve(), config=config, app="conserver")
+    juju.deploy(charm.resolve(), config=config, app=APP_NAME)
     juju.wait(jubilant.all_active, timeout=300)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,7 +1,6 @@
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-import pytest
 from ops import testing
 
 from charm import ConserverCharm
@@ -9,14 +8,71 @@ from charm import ConserverCharm
 logger = logging.getLogger(__name__)
 
 
-def test_start(monkeypatch: pytest.MonkeyPatch, config_file: str):
-    """Test that the charm has the correct state after handling the start event."""
+@patch("charm.Conserver")
+def test_invalid_base64_config_file(conserver_mock: MagicMock):
+    """Test that the charm is blocked when config-file has invalid base64 content."""
     ctx = testing.Context(ConserverCharm)
+    state_in = testing.State(
+        config={"config-file": "invalid-base64"},
+        leader=True,
+    )
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+    assert isinstance(state_out.unit_status, testing.BlockedStatus)
 
-    systemd_mock = MagicMock()
-    systemd_mock.service_running.return_value = True
-    monkeypatch.setattr("charm.systemd", systemd_mock)
 
+@patch("charm.Conserver")
+def test_invalid_base64_passwd_file(conserver_mock: MagicMock, config_file: str):
+    """Test that the charm is blocked when passwd-file has invalid base64 content."""
+    ctx = testing.Context(ConserverCharm)
+    state_in = testing.State(
+        config={
+            "config-file": config_file,
+            "passwd-file": "invalid-base64",
+        },
+        leader=True,
+    )
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+    assert isinstance(state_out.unit_status, testing.BlockedStatus)
+
+
+@patch("charm.Conserver")
+def test_install(conserver_mock: MagicMock):
+    """Test that the charm installs conserver on install event."""
+    ctx = testing.Context(ConserverCharm)
+    state_in = testing.State(leader=True)
+    ctx.run(ctx.on.install(), state_in)
+    conserver_mock.return_value.install.assert_called_once()
+
+
+@patch("charm.Conserver")
+def test_config_missing_config_file(conserver_mock: MagicMock):
+    """Test that the charm is blocked when config-file is missing."""
+    ctx = testing.Context(ConserverCharm)
+    state_in = testing.State(
+        config={"config-file": ""},
+        leader=True,
+    )
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+    assert isinstance(state_out.unit_status, testing.BlockedStatus)
+
+
+@patch("charm.Conserver")
+def test_config_missing_passwd_file(conserver_mock: MagicMock, config_file: str):
+    """Test that the charm is blocked when passwd-file is missing."""
+    ctx = testing.Context(ConserverCharm)
+    state_in = testing.State(
+        config={"config-file": config_file, "passwd-file": ""},
+        leader=True,
+    )
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+    assert isinstance(state_out.unit_status, testing.BlockedStatus)
+
+
+@patch("charm.Conserver")
+def test_start(conserver_mock: MagicMock, config_file: str):
+    """Test that the charm has the correct state after handling the start event."""
+    conserver_mock.return_value.running = True
+    ctx = testing.Context(ConserverCharm)
     state_in = testing.State(
         config={"config-file": config_file},
         leader=True,
@@ -25,33 +81,39 @@ def test_start(monkeypatch: pytest.MonkeyPatch, config_file: str):
     assert isinstance(state_out.unit_status, testing.ActiveStatus)
 
 
-def test_start_missing_config_file(monkeypatch: pytest.MonkeyPatch):
-    """Test that the charm is blocked when config-file is missing."""
-    ctx = testing.Context(ConserverCharm)
-
-    systemd_mock = MagicMock()
-    monkeypatch.setattr("charm.systemd", systemd_mock)
-
-    state_in = testing.State(
-        config={},
-        leader=True,
-    )
-    state_out = ctx.run(ctx.on.start(), state_in)
-    assert isinstance(state_out.unit_status, testing.BlockedStatus)
-
-
-def test_start_failed_service(monkeypatch: pytest.MonkeyPatch, config_file: str):
+@patch("charm.Conserver")
+def test_start_failed_service(conserver_mock: MagicMock, config_file: str):
     """Test that the charm is blocked when the service has failed."""
+    conserver_mock.return_value.running = False
+    conserver_mock.return_value.failed = True
     ctx = testing.Context(ConserverCharm)
-
-    systemd_mock = MagicMock()
-    systemd_mock.service_running.return_value = False
-    systemd_mock.service_failed.return_value = True
-    monkeypatch.setattr("charm.systemd", systemd_mock)
-
     state_in = testing.State(
         config={"config-file": config_file},
         leader=True,
     )
     state_out = ctx.run(ctx.on.start(), state_in)
     assert isinstance(state_out.unit_status, testing.BlockedStatus)
+
+
+@patch("charm.Conserver")
+def test_start_maintenance(conserver_mock: MagicMock, config_file: str):
+    """Test that the charm is in maintenance when the service is not running nor failed."""
+    conserver_mock.return_value.running = False
+    conserver_mock.return_value.failed = False
+    ctx = testing.Context(ConserverCharm)
+    state_in = testing.State(
+        config={"config-file": config_file},
+        leader=True,
+    )
+    state_out = ctx.run(ctx.on.start(), state_in)
+    assert isinstance(state_out.unit_status, testing.MaintenanceStatus)
+
+
+@patch("charm.Conserver")
+def test_stop(conserver_mock: MagicMock):
+    """Test that the charm stops and uninstalls conserver on stop event."""
+    ctx = testing.Context(ConserverCharm)
+    state_in = testing.State(leader=True)
+    ctx.run(ctx.on.stop(), state_in)
+    conserver_mock.return_value.stop.assert_called_once()
+    conserver_mock.return_value.uninstall.assert_called_once()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -71,6 +71,7 @@ def test_config_missing_passwd_file(conserver_mock: MagicMock, config_file: str)
 @patch("charm.Conserver")
 def test_start(conserver_mock: MagicMock, config_file: str):
     """Test that the charm has the correct state after handling the start event."""
+    conserver_mock.return_value.version = "8.2.6"
     conserver_mock.return_value.running = True
     ctx = testing.Context(ConserverCharm)
     state_in = testing.State(
@@ -79,11 +80,13 @@ def test_start(conserver_mock: MagicMock, config_file: str):
     )
     state_out = ctx.run(ctx.on.start(), state_in)
     assert isinstance(state_out.unit_status, testing.ActiveStatus)
+    assert state_out.workload_version == "8.2.6"
 
 
 @patch("charm.Conserver")
 def test_start_failed_service(conserver_mock: MagicMock, config_file: str):
     """Test that the charm is blocked when the service has failed."""
+    conserver_mock.return_value.version = "8.2.6"
     conserver_mock.return_value.running = False
     conserver_mock.return_value.failed = True
     ctx = testing.Context(ConserverCharm)
@@ -98,6 +101,7 @@ def test_start_failed_service(conserver_mock: MagicMock, config_file: str):
 @patch("charm.Conserver")
 def test_start_maintenance(conserver_mock: MagicMock, config_file: str):
     """Test that the charm is in maintenance when the service is not running nor failed."""
+    conserver_mock.return_value.version = "8.2.6"
     conserver_mock.return_value.running = False
     conserver_mock.return_value.failed = False
     ctx = testing.Context(ConserverCharm)

--- a/tests/unit/test_conserver.py
+++ b/tests/unit/test_conserver.py
@@ -1,0 +1,193 @@
+"""Unit tests for conserver workload."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from charmlibs import apt, systemd
+
+from conserver import CONSERVER_SERVICE, Conserver
+
+
+@patch("conserver.subprocess.run")
+@patch("conserver.apt.DebianPackage.from_system")
+def test_version(from_system_mock: MagicMock, subprocess_run_mock: MagicMock):
+    """Test that version property returns correct value."""
+    subprocess_run_mock.return_value = MagicMock(
+        stdout=b"conserver: conserver.com version 8.2.6\n", returncode=0
+    )
+    conserver = Conserver()
+    assert conserver.version == "8.2.6"
+
+
+@patch("conserver.subprocess.run")
+@patch("conserver.apt.DebianPackage.from_system")
+def test_version_unknown(from_system_mock: MagicMock, subprocess_run_mock: MagicMock):
+    """Test that version property returns 'unknown' when version cannot be determined."""
+    subprocess_run_mock.return_value = MagicMock(stdout=b"unexpected output", returncode=0)
+    conserver = Conserver()
+    assert conserver.version == "unknown"
+
+
+@patch("conserver.pwd.getpwnam")
+def test_uid(getpwnam_mock: MagicMock):
+    """Test that uid property returns correct value."""
+    mock_pwd_entry = MagicMock()
+    mock_pwd_entry.pw_uid = 1001
+    getpwnam_mock.return_value = mock_pwd_entry
+
+    conserver = Conserver()
+    assert conserver.uid == 1001
+
+
+@patch("conserver.systemd.service_running", return_value=True)
+def test_running(running_mock: MagicMock):
+    """Test that running property returns correct value."""
+    conserver = Conserver()
+    assert conserver.running is True
+    running_mock.assert_called_once_with(CONSERVER_SERVICE)
+
+
+@patch("conserver.systemd.service_failed", return_value=True)
+def test_failed(failed_mock: MagicMock):
+    """Test that failed property returns correct value."""
+    conserver = Conserver()
+    assert conserver.failed is True
+    failed_mock.assert_called_once_with(CONSERVER_SERVICE)
+
+
+@patch("conserver.Conserver.write_server_config")
+@patch("conserver.apt.DebianPackage.from_system")
+def test_install(from_system_mock: MagicMock, write_config_mock: MagicMock):
+    """Test that conserver is installed and server config is written."""
+    conserver = Conserver()
+    conserver.install()
+    conserver.conserver_deb.ensure.assert_called_with(apt.PackageState.Latest)  # type: ignore
+    write_config_mock.assert_called_once()
+
+
+@patch("conserver.apt.DebianPackage.from_system")
+def test_uninstall(from_system_mock: MagicMock):
+    """Test that conserver is uninstalled."""
+    conserver = Conserver()
+    conserver.uninstall()
+    conserver.conserver_deb.ensure.assert_called_with(apt.PackageState.Absent)  # type: ignore
+
+
+@patch("conserver.systemd.service_enable")
+def test_start(service_enable_mock: MagicMock):
+    """Test that start method enables and starts the service."""
+    conserver = Conserver()
+    conserver.start()
+    service_enable_mock.assert_called_once_with("--now", CONSERVER_SERVICE)
+
+
+@patch("conserver.systemd.service_enable", side_effect=systemd.SystemdError)
+def test_start_ignore_errors(service_enable_mock: MagicMock):
+    """Test that start method ignores errors when specified."""
+    conserver = Conserver()
+    conserver.start(ignore_errors=True)
+
+
+@patch("conserver.systemd.service_enable", side_effect=systemd.SystemdError)
+def test_start_raise_errors(service_enable_mock: MagicMock):
+    """Test that start method raises errors when not ignoring."""
+    conserver = Conserver()
+    pytest.raises(systemd.SystemdError, conserver.start, ignore_errors=False)
+
+
+@patch("conserver.systemd.service_reload")
+def test_reload(service_reload_mock: MagicMock):
+    """Test that reload method reloads the service."""
+    conserver = Conserver()
+    conserver.reload(restart_on_failure=True)
+    service_reload_mock.assert_called_once_with(CONSERVER_SERVICE, restart_on_failure=True)
+
+
+@patch("conserver.systemd.service_reload", side_effect=systemd.SystemdError)
+def test_reload_ignore_errors(service_reload_mock: MagicMock):
+    """Test that reload method ignores errors when specified."""
+    conserver = Conserver()
+    conserver.reload(ignore_errors=True)
+
+
+@patch("conserver.systemd.service_reload", side_effect=systemd.SystemdError)
+def test_reload_raise_errors(service_reload_mock: MagicMock):
+    """Test that reload method raises errors when not ignoring."""
+    conserver = Conserver()
+    pytest.raises(systemd.SystemdError, conserver.reload, ignore_errors=False)
+
+
+@patch("conserver.systemd.service_disable")
+def test_stop(service_disable_mock: MagicMock):
+    """Test that stop method disables the service."""
+    conserver = Conserver()
+    conserver.stop()
+    service_disable_mock.assert_called_once_with("--now", CONSERVER_SERVICE)
+
+
+@patch("conserver.systemd.service_disable", side_effect=systemd.SystemdError)
+def test_stop_ignore_errors(service_disable_mock: MagicMock):
+    """Test that stop method ignores errors when specified."""
+    conserver = Conserver()
+    conserver.stop(ignore_errors=True)
+
+
+@patch("conserver.systemd.service_disable", side_effect=systemd.SystemdError)
+def test_stop_raise_errors(service_disable_mock: MagicMock):
+    """Test that stop method raises errors when not ignoring."""
+    conserver = Conserver()
+    pytest.raises(systemd.SystemdError, conserver.stop, ignore_errors=False)
+
+
+@patch("conserver.Path.write_text")
+def test_write_server_config(write_text_mock: MagicMock):
+    """Test that server config is written to the correct file."""
+    conserver = Conserver()
+    conserver.write_server_config()
+    write_text_mock.assert_called_once()
+
+
+@patch("conserver.Path.write_text", side_effect=OSError)
+def test_write_server_config_failure(write_text_mock: MagicMock):
+    """Test that write_server_config raises an error on failure."""
+    conserver = Conserver()
+    pytest.raises(OSError, conserver.write_server_config)
+
+
+@patch("conserver.Path")
+@patch("conserver.os.chown")
+def test_write_conserver_config(chown_mock: MagicMock, path_mock: MagicMock):
+    """Test that conserver config is written correctly."""
+    conserver = Conserver()
+    test_content = "test conserver config"
+    conserver.write_conserver_config(test_content)
+    path_mock.return_value.write_text.assert_called_once_with(test_content, encoding="utf-8")
+    path_mock.return_value.chmod.assert_called_once()
+    chown_mock.assert_called_once()
+
+
+@patch("conserver.Path.write_text", side_effect=OSError)
+def test_write_conserver_config_failure(write_text_mock: MagicMock):
+    """Test that write_conserver_config raises an error on failure."""
+    conserver = Conserver()
+    pytest.raises(OSError, conserver.write_conserver_config, "test content")
+
+
+@patch("conserver.Conserver.uid", new_callable=MagicMock(return_value=1))
+@patch("conserver.Path")
+@patch("conserver.os.chown")
+def test_write_passwd_file(chown_mock: MagicMock, path_mock: MagicMock, uid_mock: MagicMock):
+    """Test that passwd file is written correctly."""
+    conserver = Conserver()
+    test_content = "test passwd content"
+    conserver.write_passwd_file(test_content)
+    path_mock.return_value.write_text.assert_called_once_with(test_content, encoding="utf-8")
+    path_mock.return_value.chmod.assert_called_once()
+    chown_mock.assert_called_once()
+
+
+@patch("conserver.Path.write_text", side_effect=OSError)
+def test_write_passwd_file_failure(write_text_mock: MagicMock):
+    """Test that write_passwd_file raises an error on failure."""
+    conserver = Conserver()
+    pytest.raises(OSError, conserver.write_passwd_file, "test content")

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ pass_env =
 commands =
     pytest \
         -v \
+        -x \
         -s \
         --tb native \
         --log-cli-level=INFO \


### PR DESCRIPTION
This PR does the following:

- Refactor so Conserver workload is in its own module
- Update unit tests
- Extract and set workload (conserver) version. See relevant [docs](https://documentation.ubuntu.com/ops/latest/howto/manage-the-workload-version/#how-to-set-the-workload-version)

Unit and integration tests have been updated.